### PR TITLE
Faucet: Require users to pass their own API key to the faucet

### DIFF
--- a/src/app/components/APIKey.tsx
+++ b/src/app/components/APIKey.tsx
@@ -1,0 +1,38 @@
+import React, { useState } from "react";
+
+const APIKey: React.FC<{ apiKey: string; setApiKey: (apiKey: string) => void }> = ({ apiKey, setApiKey }) => {
+    const [apiKeyTouched, setApiKeyTouched] = useState(false);
+
+    return (
+        <div className="sm:col-span-6 flex flex-col items-center">
+            <div className="w-full max-w-md">
+                <input
+                    id="apiKey"
+                    className="w-full text-center p-3 rounded-full font-mono text-lg bg-gray-200 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-600"
+                    value={apiKey}
+                    onChange={(e) => {
+                        setApiKeyTouched(true);
+                        setApiKey(e.target.value);
+                    }}
+                    placeholder="Enter your API key"
+                />
+                {apiKeyTouched && !apiKey.trim() && (
+                    <div className="text-red-500 text-sm mt-1 text-center">Please enter your API key</div>
+                )}
+            </div>
+            <div className="text-sm text-gray-500 mt-2">
+                Get your API key from{" "}
+                <a
+                    href="https://staging.crossmint.com"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-blue-500 hover:text-blue-600"
+                >
+                    staging.crossmint.com
+                </a>
+            </div>
+        </div>
+    );
+};
+
+export default APIKey;

--- a/src/app/components/Faucet.tsx
+++ b/src/app/components/Faucet.tsx
@@ -7,11 +7,13 @@ import { CryptoCurrency } from "../types/currencies/CryptoCurrencies";
 import Currencies from "./Currencies";
 import { useFundWallet } from "../hooks/useFundWallet";
 import { UsdcEnabledTestnet, UsdcEnabledTestnetChains } from "../types/blockchain/BlockChains";
+import APIKey from "./APIKey";
 
 const Faucet: React.FC = () => {
     const { fundWallet, fundWalletLoading, error } = useFundWallet();
     const [amount, setAmount] = useState(30);
     const [address, setAddress] = useState("");
+    const [apiKey, setApiKey] = useState("");
     const [currency, setCurrency] = useState<CryptoCurrency>(CryptoCurrency.USDC);
     const [addressTouched, setAddressTouched] = useState(false);
     const [chain, setChain] = useState<UsdcEnabledTestnet>(UsdcEnabledTestnetChains.ETHEREUM_SEPOLIA);
@@ -32,15 +34,17 @@ const Faucet: React.FC = () => {
             <CrossmintChains chain={chain} onChainChange={setChain} />
             <Amount amount={amount} setAmount={setAmount} currency={currency} />
             <Preview amount={amount} address={address} chain={chain} currency={currency} />
+            <APIKey apiKey={apiKey} setApiKey={setApiKey} />
             <button
                 className="w-40 px-4 py-2 my-4 rounded-md text-white font-mono bg-blue-500 disabled:bg-gray-400"
-                disabled={fundWalletLoading || !address.trim()}
+                disabled={fundWalletLoading || !address.trim() || !apiKey.trim()}
                 onClick={() => {
                     fundWallet({
                         amount,
                         address,
                         chain: chain,
                         currency,
+                        apiKey: apiKey,
                     });
                 }}
             >

--- a/src/app/hooks/useFundWallet.tsx
+++ b/src/app/hooks/useFundWallet.tsx
@@ -8,6 +8,7 @@ export interface FundWalletProps {
     address: string;
     chain: UsdcEnabledTestnet;
     currency: CryptoCurrency;
+    apiKey: string;
 }
 
 export type FundWalletResponse = {
@@ -54,7 +55,10 @@ export function FundWalletProvider({
         try {
             const response = await fetchPostJson<FundWalletResponse>(
                 `https://staging.crossmint.com/api/v1-alpha2/wallets/${props.address}/balances`,
-                fundWalletBody
+                fundWalletBody,
+                {
+                    "x-api-key": props.apiKey,
+                }
             );
             setFundWalletLoading(false);
             setFundWalletResponse(response);

--- a/src/app/utils.ts
+++ b/src/app/utils.ts
@@ -5,8 +5,6 @@ export async function fetchPostJson<T>(url: string, body: any, headers: Record<s
             method: "POST",
             headers: {
                 "Content-Type": "application/json",
-                "x-api-key":
-                    "ck_staging_666s34kJSUV71hV78mG9XcC4eVhMntGSNfvftj4EXgKPAqvnCDtJrJdUiygBMP1tgHNg3mWZmVuz5YQsXMorwiCYAAa84RSsa9kK4M9Wx1rVZMM4rciXC4R6vf5JP8dJRabCP2kU7NF3orYu8LsWvJYrTjMNAUTc6WrX1KA26W8DP73ivP2iZHyLFt33HwVF4oBJFrdPfSkVax7ErSknZyvQ",
                 ...headers,
             },
             body: JSON.stringify(body),


### PR DESCRIPTION
# Description
Context: Users have been draining our faucet. To rate limit them, we can have them pass their API key.
This will get them to use Crossmint and we can rate limit based on the project.

# Test
**Normal state**
<img width="1080" alt="image" src="https://github.com/user-attachments/assets/a1215029-658b-4d96-8559-9571d0312bf4">

**Not filled in**
<img width="1078" alt="image" src="https://github.com/user-attachments/assets/e61c9221-2397-48de-bf64-de653daa53cd">

**Malformed key**
<img width="1010" alt="image" src="https://github.com/user-attachments/assets/dc479be1-96d0-4bbd-8450-4e4676f6fc84">

**Successful Request**
<img width="1052" alt="image" src="https://github.com/user-attachments/assets/0189a1df-876a-4c33-b1c8-784a8bcc8491">
